### PR TITLE
Unify query methods & add `from_dataframe` method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
- ☐ v0.1
-   ☐ task1
-   ☐ task2
-   ☐ task3
+ ✔ v0.1 @done (16-05-19 15:44)
+   ✔ Connection with context managment @done (16-05-19 15:44)
+   ✔ Read method @done (16-05-19 15:44)
+   ✔ Write method @done (16-05-19 15:44)
+   ✔ SQL query to pandas DataFrame @done (16-05-19 15:44)
+ ✔ v0.2 @done (16-05-19 15:44)
+   ✔ insert pandas DataFrame into table @done (16-05-19 15:44)
+   ✔ unify query methods @done (16-05-19 15:44)

--- a/README.md
+++ b/README.md
@@ -7,23 +7,28 @@ pip install pypostgres
 # Usage
 
 ```python
-from pypostgres import Postgres
+>>> from postgres import Postgres
 
 # Database connection
-db = Postgres('dbname', 'user')
+>>> db = Postgres('dbname', 'user')
 
 # Execute query
->>> db.query('SELECT * FROM test;', mode='read')
+>>> db.query('SELECT * FROM dbname;', mode='read')
 >>> [(1, 99, "def'abc"), (2, 100, "abc'def")]
 
 # Insert query
->>> db.query('INSERT INTO test (a, b) VALUES (%s, %s);', (1, 2), mode='write')
+>>> db.query('INSERT INTO dbname (a, b) VALUES (%s, %s);', (1, 2), mode='write')
 # return None
 
 # DataFrame query
->>> db.to_dataframe(['id', 'num', 'data'], 'test')
+>>> db.to_dataframe(['id', 'num', 'data'], 'dbname', conditions="num > 1")
 >>> 
     id    num       data
 0  2.0  100.0  "abc'def"
 
+# Inserting a DataFrame
+>>> import pandas as pd
+>>> df = pd.DataFrame([(3, 98, 'test')], columns=['id', 'num', 'data'])
+>>> db.from_dataframe(df, 'dbname')
+# return None
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 pip install pypostgres
 ```
 
+*Not tested in python 2.x*
+
 # Usage
 
 ```python

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ pip install pypostgres
 # Usage
 
 ```python
->>> from postgres import Postgres
+>>> from pypostgres import Postgres
 
 # Database connection
 >>> db = Postgres('dbname', 'user')

--- a/README.md
+++ b/README.md
@@ -12,11 +12,18 @@ from pypostgres import Postgres
 # Database connection
 db = Postgres('dbname', 'user')
 
-# Select query
-db.read('SELECT * FROM test;')
-# return a list of tuples
+# Execute query
+>>> db.query('SELECT * FROM test;', mode='read')
+>>> [(1, 99, "def'abc"), (2, 100, "abc'def")]
 
 # Insert query
-db.write('INSERT INTO test (a, b) VALUES (%s, %s);', (1, 2))
+>>> db.query('INSERT INTO test (a, b) VALUES (%s, %s);', (1, 2), mode='write')
 # return None
+
+# DataFrame query
+>>> db.to_dataframe(['id', 'num', 'data'], 'test')
+>>> 
+    id    num       data
+0  2.0  100.0  "abc'def"
+
 ```

--- a/TODO
+++ b/TODO
@@ -1,7 +1,9 @@
 # feature request  vs tasks to do
  ✔ basic setup of the repository tree @done (16-05-18 23:29)
+ ✔ usable & stable version @done (16-05-19 15:49)
  ☐ add tests
  ☐ setup CI configuration with travis
  ☐ allow coverage report
  ☐ write the docstrings for all functions
  ☐ write a properly readme.md with gifs showing the basic usage
+ ☐ add error treatment for all functions

--- a/pypostgres/__init__.py
+++ b/pypostgres/__init__.py
@@ -2,7 +2,7 @@
 # coding=utf-8
 
 
-__version__ = '0.1'
+__version__ = '0.2'
 __author__ = ['Marcellus Amadeus', 'Manoel Vilela']
 __email__ = ['marcellus@nexusedge.com.br', 'manoel.vilela@nexusedge.com.br']
 __url__ = 'https://www.github.com/marcelluz/postgresql'

--- a/pypostgres/pypostgres.py
+++ b/pypostgres/pypostgres.py
@@ -29,23 +29,24 @@ class Postgres():
         self.db = db
         self.user = user
 
-    def read(self, query):
-        with Connection(self.db, self.user) as cursor:
-            cursor.execute(query)
-            return cursor.fetchall()
-
-    def write(self, query, insertion=None):
+    def query(self, query, insertion=None, mode=['read', 'write']):
         with Connection(self.db, self.user) as cursor:
             cursor.execute(query, insertion)
+            if mode == 'read':
+                return cursor.fetchall()
+        return
 
     def to_dataframe(self, columns, table):
         df = pd.DataFrame(columns=columns)
         columns = ', '.join(df.columns)
+
         if conditions:
-            result = self.read("SELECT {} FROM {} WHERE {};".format(
-                columns, table, conditions))
+            query = "SELECT {} FROM {} WHERE {};".format(
+                columns, table, conditions)
         else:
-            result = self.read("SELECT {} FROM {};".format(columns, table))
+            query = "SELECT {} FROM {};".format(columns, table)
+            
+        result = self.query(query, mode='read')
         for index, items in enumerate(result):
             df.loc[index] = items
         return df

--- a/pypostgres/pypostgres.py
+++ b/pypostgres/pypostgres.py
@@ -45,3 +45,11 @@ class Postgres():
         for index, items in enumerate(result):
             df.loc[index] = items
         return df
+
+    def from_dataframe(self, df, table):
+        columns = ', '.join(df.columns)
+        placeholder = ', '.join(repeat('%s', len(df.columns)))
+        query = "INSERT INTO {} ({}) VALUES ({})".format(
+            table, columns, placeholder)
+        for row in df.itertuples():
+            self.write(query, insertion=row)

--- a/pypostgres/pypostgres.py
+++ b/pypostgres/pypostgres.py
@@ -41,7 +41,11 @@ class Postgres():
     def to_dataframe(self, columns, table):
         df = pd.DataFrame(columns=columns)
         columns = ', '.join(df.columns)
-        result = self.read("SELECT {} FROM {};".format(columns, table))
+        if conditions:
+            result = self.read("SELECT {} FROM {} WHERE {};".format(
+                columns, table, conditions))
+        else:
+            result = self.read("SELECT {} FROM {};".format(columns, table))
         for index, items in enumerate(result):
             df.loc[index] = items
         return df

--- a/pypostgres/pypostgres.py
+++ b/pypostgres/pypostgres.py
@@ -38,7 +38,7 @@ class Postgres():
         with Connection(self.db, self.user) as cursor:
             cursor.execute(query, insertion)
 
-    def to_dataframe(self, columns, table, conditions=None):
+    def to_dataframe(self, columns, table):
         df = pd.DataFrame(columns=columns)
         columns = ', '.join(df.columns)
         result = self.read("SELECT {} FROM {};".format(columns, table))


### PR DESCRIPTION
# Query unification
`.read()` and `.write()` methods are together now, use `.query(query, mode=['read', 'write'])`. The only difference between them is that `read` returns the values in the cursor and `write` returns `None`.

# Inserting from a DataFrame
Implemented the method `.from_dataframe()`. Now you just need to provide the *DataFrame* and the table name to persist the whole *DataFrame*.