### PR TITLE
Using param fetch_size for returning pk or not when insert and commit option

### DIFF
--- a/pypostgres/cursor.py
+++ b/pypostgres/cursor.py
@@ -10,11 +10,12 @@ class Cursor(object):
         self.values = values
         self.cursor_factory = cursor_factory
         self.fetch_size = fetch_size
+        self.pk = self.fetch(fetch_size) if values else None
 
     def __repr__(self):
         return '<Cursor (%s, %s)>' % (self.sql, self.values)
 
-    def fetch(self, size=0, fetch=True):
+    def fetch(self, size=None):
         with self.connection as conn:
             with conn.cursor() as cursor:
                 if self.values is not None:
@@ -24,7 +25,7 @@ class Cursor(object):
                         cursor.execute(self.sql, self.values)
                 else:
                     cursor.execute(self.sql)
-                if size is not None and fetch:
+                if size is not None:
                     if size in (1, 'one'):
                         return cursor.fetchone()
                     elif size in (0, '*', 'all'):
@@ -44,5 +45,5 @@ class Cursor(object):
     def many(self, size):
         return self.fetch(size)
 
-    def commit(self, fetch=False):
-        return self.fetch(1, fetch=fetch)
+    def commit(self):
+        self.pk = self.fetch(self.fetch_size) if self.fetch_size else self.fetch()

--- a/pypostgres/utils.py
+++ b/pypostgres/utils.py
@@ -5,7 +5,7 @@ from psycopg2 import extras
 
 def is_nested(values):
     '''Check if values is composed only by iterable elements.'''
-    return (all(isinstance(item, Iterable) for item in values)
+    return (all(isinstance(item, list) or isinstance(item, tuple) for item in values)
             if isinstance(values, Iterable) else False)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 psycopg2==2.7.1
+pytest==3.1.0
+testing.postgresql==1.3.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'lucas'

--- a/tests/test_pypostgres.py
+++ b/tests/test_pypostgres.py
@@ -1,0 +1,82 @@
+import psycopg2
+import pytest
+import testing.postgresql
+
+from pypostgres.postgres import Postgres
+
+
+def create_database(cursor):
+    cursor.execute(
+        'CREATE TABLE test (id INTEGER , message varchar(3000), PRIMARY KEY (id));'
+    )
+
+
+@pytest.fixture
+def fake_database():
+    with testing.postgresql.Postgresql() as postgresql:
+        db = psycopg2.connect(**postgresql.dsn())
+        cur = db.cursor()
+        create_database(cur)
+        db.commit()
+        yield postgresql.dsn()
+
+        db.close()
+
+
+def test_insert_one_without_fetch(fake_database):
+    db = Postgres(**fake_database)
+    cursor = db.query(
+        "insert into test (id, message) values (1, 'test_message')"
+    )
+    pk = cursor.commit()
+    assert not pk
+    query_test = db.query("select count(*) from test")
+    assert len(query_test.all) == 1
+
+
+def test_insert_one_with_fetch(fake_database):
+    db = Postgres(**fake_database)
+    cursor = db.query(
+        "insert into test (id, message) values (1, 'test_message') returning id")
+    pk = cursor.commit(fetch=True)
+    assert pk[0] == 1
+
+
+@pytest.mark.parametrize('values, expected_count ', [
+    [[(i,  'insert '+ str(i))for i in range(1, 4)], 3],
+    [[(i, 'insert '+ str(i)) for i in range(1, 6)], 5],
+])
+def test_insert_bulk(fake_database, values, expected_count):
+    db = Postgres(**fake_database)
+    sql = 'insert into test (id, message) values (%s, %s)'
+    cursor = db.query(sql=sql, values=values)
+    cursor.commit()
+    query_test = db.query("select count(*) from test")
+    assert query_test.one[0] == expected_count
+
+
+@pytest.mark.parametrize('values, return_id', [
+    [[(i,  'insert '+ str(i))for i in range(1, 4)], 1],
+    [[(i,  'insert '+ str(i))for i in range(1, 10)], 5],
+])
+def test_select_one(fake_database, values, return_id):
+    db = Postgres(**fake_database)
+    sql = 'insert into test (id, message) values (%s, %s)'
+    cursor = db.query(sql=sql, values=values)
+    cursor.commit()
+    query_test = db.query(sql="select * from test where id=%s", values=(return_id, ))
+    result = query_test.one
+    assert result == (values[return_id-1])
+
+
+@pytest.mark.parametrize('values', [
+    [(i,  'insert '+ str(i))for i in range(1, 4)],
+    [(i,  'insert '+ str(i))for i in range(1, 10)],
+])
+def test_select_all(fake_database, values):
+    db = Postgres(**fake_database)
+    sql = 'insert into test (id, message) values (%s, %s)'
+    cursor = db.query(sql=sql, values=values)
+    cursor.commit()
+    query_test = db.query(sql="select * from test")
+    assert query_test.all == values

--- a/tests/test_pypostgres.py
+++ b/tests/test_pypostgres.py
@@ -1,8 +1,7 @@
 import psycopg2
-from pypostgres.cursor import Cursor
 import pytest
 import testing.postgresql
-
+from pypostgres.cursor import Cursor
 from pypostgres.postgres import Postgres
 
 
@@ -45,8 +44,6 @@ def test_insert_one_return_pk(fake_database):
     assert query.pk[0] == 1
 
 
-
-
 def test_insert_one_without_values_using_commit(fake_database):
     db = Postgres(**fake_database)
     query = db.query(
@@ -81,6 +78,7 @@ def test_insert_bulk(fake_database, values, expected_count):
     db.query(sql=sql, values=values)
     query_test = db.query("select count(*) from test")
     assert query_test.one[0] == expected_count
+
 
 @pytest.mark.parametrize('values, return_id', [
     [[(i,  'insert '+ str(i))for i in range(1, 4)], 1],


### PR DESCRIPTION
Added attribute pk to cursor, when an insert query is executed, if fetch_size is passed, the attribute pk will have a query result.
Other change is related 'commit'  option if i do the query like this:

`db.query(sql='insert_query', values=(n,))`

the data is inserted automaticly on database.
but if i do the query like this:
```
cursor = db.query(sql='insert_query')
cursor.commit()
```
the data is inserted on database only after commit().

Examples can be view on tests package.

